### PR TITLE
Parse arrays with a single item and no numbering

### DIFF
--- a/html_json_forms/utils.py
+++ b/html_json_forms/utils.py
@@ -100,10 +100,11 @@ def parse_json_path(path):
     while path:
         # Step 8.1 - Check for single-item array
         if path[:2] == "[]":
-            steps[-1].append = True
             path = path[2:]
-            if path:
-                return failed
+            steps.append(JsonStep(
+                type="array",
+                key=0,
+            ))
             continue
 
         # Step 8.2 - Check for array[index]

--- a/tests/test_json_forms.py
+++ b/tests/test_json_forms.py
@@ -177,3 +177,22 @@ class TestHtmlJsonExamples(unittest.TestCase):
         }
         result = parse_json_form(input_data)
         assert result == expected_output
+
+    def test_single_element_array(self):
+        """
+        Test array with single item and no digit in key
+        """
+        input_data = {
+            "simple_key": "simple",
+            "nested[][nested_key_1]": "nested_value_1",
+            "nested[][nested_key_2]": "nested_value_2",
+        }
+        expected_output = {
+            "simple_key": "simple",
+            "nested": [{
+                "nested_key_1": "nested_value_1",
+                "nested_key_2": "nested_value_2",
+            }],
+        }
+        result = parse_json_form(input_data)
+        assert result == expected_output


### PR DESCRIPTION
This patch fixes an issue when integrating with
mozilla-services/react-jsonschema-form where only one item is in an
array.

Example:

    {
        "nested[][nested_key_1]": "nested_value_1",
        "nested[][nested_key_2]": "nested_value_2",
    }

With this patch the result is (instead of the original example above):

    {
        "nested": [{
	    "nested_key_1": "nested_value_1",
	    "nested_key_2": "nested_value_2",
        }],
    }